### PR TITLE
redirects: add links to external AMP libraries/projects

### DIFF
--- a/_redirects/polarfire-soc/external/linux-kernel-doc-rpmsg.md
+++ b/_redirects/polarfire-soc/external/linux-kernel-doc-rpmsg.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/linux-kernel-doc-rpmsg
+target: https://www.kernel.org/doc/html/latest/staging/rpmsg.html
+targetname: linux-kernel-doc-rpmsg
+targettitle: taking you to linux-kernel-doc-rpmsg
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/external/repo-openamp.md
+++ b/_redirects/polarfire-soc/external/repo-openamp.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-openamp
+target: https://github.com/OpenAMP/open-amp
+targetname: repo-openamp
+targettitle: taking you to repo-openamp
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/external/repo-rpmsg-lite.md
+++ b/_redirects/polarfire-soc/external/repo-rpmsg-lite.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-rpmsg-lite
+target: https://github.com/nxp-mcuxpresso/rpmsg-lite
+targetname: repo-rpmsg-lite
+targettitle: taking you to repo-rpmsg-lite
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
Add redirects for OpenAMP, RPMSG-lite and Linux kernel RPMsg documentations. This documents are provided as reference as part of the RPMsg documentation in the polarfire-soc-documentation repo.

Signed-off-by: Valentina Fernandez <valentina.fernandezalanis@microchip.com>